### PR TITLE
Prevent panic on incomplete entries and validate previous-translation continuationsFix/po parser entry validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Publish (dry run)
         run: |
           cd rust
-          cargo package -v --dry-run
+          cargo publish -v --dry-run
 
   release-rust-crate:
     name: Release Rust crate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12.1"
-          pip-version: "25.0.1"
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -82,7 +81,6 @@ jobs:
           PIP_DISABLE_PIP_VERSION_CHECK: 1
         with:
           python-version: ${{ matrix.python-version }}
-          pip-version: "25.0.1"
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -160,10 +158,10 @@ jobs:
         uses: hecrj/setup-rust-action@v2
         with:
           rust-version: stable
-      - name: Package
+      - name: Publish (dry run)
         run: |
           cd rust
-          cargo package -v
+          cargo package -v --dry-run
 
   release-rust-crate:
     name: Release Rust crate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,10 @@ jobs:
         uses: hecrj/setup-rust-action@v2
         with:
           rust-version: stable
-      - name: Publish
+      - name: Package
         run: |
           cd rust
-          cargo login ${{ secrets.CRATES_TOKEN }}
-          cargo publish -v --dry-run
+          cargo package -v
 
   release-rust-crate:
     name: Release Rust crate
@@ -174,9 +173,10 @@ jobs:
         with:
           rust-version: stable
       - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
         run: |
           cd rust
-          cargo login ${{ secrets.CRATES_TOKEN }}
           cargo publish -v
 
   release-py-wheels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12.1"
+          pip-version: "25.0.1"
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -76,9 +77,12 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
         with:
           python-version: ${{ matrix.python-version }}
+          pip-version: "25.0.1"
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,9 @@ jobs:
           args: --release --sdist -o dist --find-interpreter
           working-directory: python
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux
           path: python/dist
 
   windows-py-wheels:
@@ -124,9 +124,9 @@ jobs:
           args: --release -o dist --find-interpreter
           working-directory: python
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows
           path: python/dist
 
   macos-py-wheels:
@@ -143,7 +143,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos
           path: python/dist
 
   test-release-rust-crate:
@@ -190,11 +190,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         with:
           command: upload
-          args: --skip-existing *
+          args: --skip-existing dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2026-01-08 - [0.1.2]
+
+### Bug fixes
+
+- Incomplete entries (msgctxt/msgid without msgstr) could trigger a panic when a new entry begins.
+- Previous-translation continuation lines (#| "...") could be accepted without a preceding #| msgid/msgctxt/msgid_plural context.
+
 ## 2025-01-20 - [0.1.1]
 
 - Add MSRV.
@@ -14,6 +21,7 @@ First beta release.
 
 Alpha releases.
 
+[0.1.2]: https://github.com/mondeja/rspolib/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/mondeja/rspolib/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mondeja/rspolib/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/mondeja/rspolib/compare/v0.0.1...v0.0.5

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rspolib"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 readme = "README.md"
 description = "Python bindings for the Rust crate rspolib."

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "rspolib"
 version = "0.1.1"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.14"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -17,5 +17,4 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspolib"
-version = "0.1.1"
+version = "0.1.2"
 rust-version = "1.66.1"
 edition = "2021"
 readme = "../README.md"

--- a/rust/src/file/mod.rs
+++ b/rust/src/file/mod.rs
@@ -57,11 +57,11 @@ pub trait SaveAsMOFile {
 ///   big endian byte order.
 pub trait AsBytes {
     /// Return the content as bytes
-    fn as_bytes(&self) -> Cow<[u8]>;
+    fn as_bytes(&self) -> Cow<'_, [u8]>;
     /// Return the content as bytes in little endian encoding
-    fn as_bytes_le(&self) -> Cow<[u8]>;
+    fn as_bytes_le(&self) -> Cow<'_, [u8]>;
     /// Return the content as bytes in big endian encoding
-    fn as_bytes_be(&self) -> Cow<[u8]>;
+    fn as_bytes_be(&self) -> Cow<'_, [u8]>;
 }
 
 /// File options struct passed when creating a new PO or MO file

--- a/rust/src/file/mofile.rs
+++ b/rust/src/file/mofile.rs
@@ -219,7 +219,7 @@ impl MOFile {
         &self,
         magic_number: u32,
         revision_number: u32,
-    ) -> Cow<[u8]> {
+    ) -> Cow<'_, [u8]> {
         let metadata_entry = self.metadata_as_entry();
 
         // Select byte order based on magic number
@@ -372,17 +372,17 @@ impl SaveAsMOFile for MOFile {
 
 impl AsBytes for MOFile {
     /// Return the MOFile as a vector of bytes in little endian
-    fn as_bytes(&self) -> Cow<[u8]> {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
         self.as_bytes_with(MAGIC, 0)
     }
 
     /// Return the MOFile as a vector of bytes in little endian
-    fn as_bytes_le(&self) -> Cow<[u8]> {
+    fn as_bytes_le(&self) -> Cow<'_, [u8]> {
         self.as_bytes_with(MAGIC, 0)
     }
 
     /// Return the MOFile as a vector of bytes in big endian
-    fn as_bytes_be(&self) -> Cow<[u8]> {
+    fn as_bytes_be(&self) -> Cow<'_, [u8]> {
         self.as_bytes_with(MAGIC_SWAPPED, 0)
     }
 }

--- a/rust/src/file/pofile.rs
+++ b/rust/src/file/pofile.rs
@@ -490,7 +490,7 @@ impl AsBytes for POFile {
     /// let file = pofile("tests-data/all.po").unwrap();
     /// let bytes = MOFile::from(&file).as_bytes_with(MAGIC_SWAPPED, 1);
     /// ```
-    fn as_bytes(&self) -> Cow<[u8]> {
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
         let mofile = MOFile::from(self);
         let result = mofile.as_bytes_with(MAGIC, 0);
         Cow::Owned(result.into_owned())
@@ -499,13 +499,13 @@ impl AsBytes for POFile {
     /// Return the PO file content as a bytes vector of the MO file version
     ///
     /// Just an alias for [POFile::as_bytes], for consistency with [MOFile].
-    fn as_bytes_le(&self) -> Cow<[u8]> {
+    fn as_bytes_le(&self) -> Cow<'_, [u8]> {
         self.as_bytes()
     }
 
     /// Return the PO file content as a bytes vector of
     /// the MO file version with big endianess
-    fn as_bytes_be(&self) -> Cow<[u8]> {
+    fn as_bytes_be(&self) -> Cow<'_, [u8]> {
         let mofile = MOFile::from(self);
         let result = mofile.as_bytes_with(MAGIC_SWAPPED, 0);
         Cow::Owned(result.into_owned())

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -148,6 +148,50 @@ impl POFileParser {
         Ok(())
     }
 
+    fn missing_msgstr_error(&self, line: usize) -> SyntaxError {
+        SyntaxError::Custom {
+            maybe_filename: MaybeFilename::new(
+                &self.file.options.path_or_content,
+                self.content_is_path,
+            ),
+            line,
+            index: 0,
+            message: "missing 'msgstr' section".to_string(),
+        }
+    }
+
+    fn missing_plural_msgstr_error(
+        &self,
+        line: usize,
+    ) -> SyntaxError {
+        SyntaxError::Custom {
+            maybe_filename: MaybeFilename::new(
+                &self.file.options.path_or_content,
+                self.content_is_path,
+            ),
+            line,
+            index: 0,
+            message: "missing plural 'msgstr[n]' section".to_string(),
+        }
+    }
+
+    fn validate_current_entry_complete(
+        &self,
+        line: usize,
+    ) -> Result<(), SyntaxError> {
+        if self.current_entry.msgstr.is_none()
+            && self.current_entry.msgid_plural.is_none()
+        {
+            return Err(self.missing_msgstr_error(line));
+        }
+        if self.current_entry.msgid_plural.is_some()
+            && self.current_entry.msgstr_plural.is_empty()
+        {
+            return Err(self.missing_plural_msgstr_error(line));
+        }
+        Ok(())
+    }
+
     fn process(
         &mut self,
         symbol: &Symbol,
@@ -210,6 +254,7 @@ impl POFileParser {
                 }
             }
         } else {
+            self.validate_current_entry_complete(self.current_line)?;
             self.add_current_entry()?;
         }
 
@@ -282,6 +327,22 @@ impl POFileParser {
         if nb_tokens > 1 && KEYWORDS.contains_key(&tokens[0]) {
             line = line[tokens[0].len()..].trim_start();
 
+            let symbol = *KEYWORDS.get(&tokens[0]).unwrap();
+            if self.current_state == St::MI
+                && [St::CT, St::MI].contains(symbol)
+            {
+                return Err(
+                    self.missing_msgstr_error(self.current_line),
+                );
+            }
+            if self.current_state == St::MP
+                && [St::CT, St::MI].contains(symbol)
+            {
+                return Err(
+                    self.missing_plural_msgstr_error(self.current_line),
+                );
+            }
+
             maybe_raise_unescaped_double_quote_found_error(
                 line,
                 self.current_line,
@@ -292,7 +353,6 @@ impl POFileParser {
                 tokens[0].chars().count() + 2,
             )?;
             self.current_token = line.to_string();
-            let symbol = *KEYWORDS.get(&tokens[0]).unwrap();
             self.process(symbol)?;
             return Ok(());
         }
@@ -1611,7 +1671,7 @@ mod tests {
         assert_eq!(
             result,
             Err(SyntaxError::Custom {
-                maybe_filename: MaybeFilename::new(content, false),
+                maybe_filename: MaybeFilename::new(content, false,),
                 line: 4,
                 index: 0,
                 message: "missing 'msgstr' section".to_string(),
@@ -1634,7 +1694,7 @@ mod tests {
         assert_eq!(
             result,
             Err(SyntaxError::Custom {
-                maybe_filename: MaybeFilename::new(content, false),
+                maybe_filename: MaybeFilename::new(content, false,),
                 line: 3,
                 index: 0,
                 message: "missing plural 'msgstr[n]' section".to_string(),

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -1592,6 +1592,53 @@ mod tests {
     }
 
     #[test]
+    fn error_when_missing_msgstr_before_next_entry() {
+        let content = concat!(
+            "msgctxt \"context:\"\n",
+            "msgid \"hello\"\n",
+            "\n",
+            "msgctxt \"next:\"\n",
+            "msgid \"foo\"\n",
+            "msgstr \"bar\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false),
+                line: 4,
+                index: 0,
+                message: "missing 'msgstr' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn error_when_missing_plural_msgstr_before_next_entry() {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "msgid_plural \"hellos\"\n",
+            "msgctxt \"next:\"\n",
+            "msgid \"foo\"\n",
+            "msgstr \"bar\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false),
+                line: 3,
+                index: 0,
+                message: "missing plural 'msgstr[n]' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
     fn error_when_unclosed_string_delimiter() {
         let path = "tests-data/unclosed-string-delimiter.po";
         let mut parser = POFileParser::new(path.into());

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -148,6 +148,10 @@ impl POFileParser {
         Ok(())
     }
 
+    fn entry_started(&self) -> bool {
+        !self.current_entry.msgid.is_empty()
+    }
+
     fn missing_msgstr_error(&self, line: usize) -> SyntaxError {
         SyntaxError::Custom {
             maybe_filename: MaybeFilename::new(
@@ -261,7 +265,7 @@ impl POFileParser {
             self.parse_line(&line)?;
         }
 
-        if self.current_entry.msgid.is_empty() {
+        if !self.entry_started() {
             // Adding header entry
             if let Some(msgstr) = &self.current_entry.msgstr {
                 if !msgstr.is_empty() {
@@ -344,7 +348,7 @@ impl POFileParser {
 
             let symbol = *KEYWORDS.get(&tokens[0]).unwrap();
             if [St::CT, St::MI].contains(symbol)
-                && !self.current_entry.msgid.is_empty()
+                && self.entry_started()
             {
                 self.validate_current_entry_complete(
                     self.current_line,

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -1654,6 +1654,53 @@ mod tests {
     }
 
     #[test]
+    fn error_when_conflict_marker_found() {
+        let content = concat!(
+            "<<<<<<< HEAD\n",
+            "msgid \"hello\"\n",
+            "msgstr \"ok\"\n",
+            "=======\n",
+            "msgid \"hello\"\n",
+            "msgstr \"maybe\"\n",
+            ">>>>>>> branch\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Generic {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 1,
+                index: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn error_when_conflict_marker_found_in_entry() {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "<<<<<<< HEAD\n",
+            "msgstr \"ok\"\n",
+            "=======\n",
+            "msgstr \"maybe\"\n",
+            ">>>>>>> branch\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Generic {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 2,
+                index: 0,
+            })
+        );
+    }
+
+    #[test]
     fn error_when_non_digit_msgstr_plural_index() {
         let content = concat!(
             "#\n",

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -455,21 +455,19 @@ impl POFileParser {
                 if ![St::PM, St::PP, St::PC]
                     .contains(&self.current_state)
                 {
-                    return Err(
-                        self.invalid_previous_continuation_error(
+                    return Err(self
+                        .invalid_previous_continuation_error(
                             self.current_line,
-                        ),
-                    );
+                        ));
                 }
 
                 let quote_index = match line.find('"') {
                     Some(index) => index,
                     None => {
-                        return Err(
-                            self.invalid_previous_continuation_error(
+                        return Err(self
+                            .invalid_previous_continuation_error(
                                 self.current_line,
-                            ),
-                        );
+                            ));
                     }
                 };
                 let continuation = &line[quote_index..];
@@ -1739,6 +1737,75 @@ mod tests {
     }
 
     #[test]
+    fn error_when_missing_msgstr_before_next_entry_with_generated_comment(
+    ) {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "#. comment\n",
+            "msgid \"next\"\n",
+            "msgstr \"ok\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 3,
+                index: 0,
+                message: "missing 'msgstr' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn error_when_missing_msgstr_before_next_entry_with_occurrence_comment(
+    ) {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "#: path.rs:10\n",
+            "msgid \"next\"\n",
+            "msgstr \"ok\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 3,
+                index: 0,
+                message: "missing 'msgstr' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn error_when_missing_msgstr_before_next_entry_with_flags_comment(
+    ) {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "#, fuzzy\n",
+            "msgid \"next\"\n",
+            "msgstr \"ok\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 3,
+                index: 0,
+                message: "missing 'msgstr' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
     fn error_when_missing_plural_msgstr_before_next_entry() {
         let content = concat!(
             "msgid \"hello\"\n",
@@ -1756,13 +1823,15 @@ mod tests {
                 maybe_filename: MaybeFilename::new(content, false,),
                 line: 3,
                 index: 0,
-                message: "missing plural 'msgstr[n]' section".to_string(),
+                message: "missing plural 'msgstr[n]' section"
+                    .to_string(),
             })
         );
     }
 
     #[test]
-    fn error_when_missing_plural_msgstr_before_next_entry_with_comment() {
+    fn error_when_missing_plural_msgstr_before_next_entry_with_comment(
+    ) {
         let content = concat!(
             "msgid \"hello\"\n",
             "msgid_plural \"hellos\"\n",
@@ -1779,7 +1848,8 @@ mod tests {
                 maybe_filename: MaybeFilename::new(content, false,),
                 line: 4,
                 index: 0,
-                message: "missing plural 'msgstr[n]' section".to_string(),
+                message: "missing plural 'msgstr[n]' section"
+                    .to_string(),
             })
         );
     }
@@ -1800,7 +1870,8 @@ mod tests {
                 maybe_filename: MaybeFilename::new(content, false,),
                 line: 1,
                 index: 0,
-                message: "invalid previous continuation line".to_string(),
+                message: "invalid previous continuation line"
+                    .to_string(),
             })
         );
     }

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -192,6 +192,21 @@ impl POFileParser {
         Ok(())
     }
 
+    fn invalid_previous_continuation_error(
+        &self,
+        line: usize,
+    ) -> SyntaxError {
+        SyntaxError::Custom {
+            maybe_filename: MaybeFilename::new(
+                &self.file.options.path_or_content,
+                self.content_is_path,
+            ),
+            line,
+            index: 0,
+            message: "invalid previous continuation line".to_string(),
+        }
+    }
+
     fn process(
         &mut self,
         symbol: &Symbol,
@@ -328,19 +343,12 @@ impl POFileParser {
             line = line[tokens[0].len()..].trim_start();
 
             let symbol = *KEYWORDS.get(&tokens[0]).unwrap();
-            if self.current_state == St::MI
-                && [St::CT, St::MI].contains(symbol)
+            if [St::CT, St::MI].contains(symbol)
+                && !self.current_entry.msgid.is_empty()
             {
-                return Err(
-                    self.missing_msgstr_error(self.current_line),
-                );
-            }
-            if self.current_state == St::MP
-                && [St::CT, St::MI].contains(symbol)
-            {
-                return Err(
-                    self.missing_plural_msgstr_error(self.current_line),
-                );
+                self.validate_current_entry_complete(
+                    self.current_line,
+                )?;
             }
 
             maybe_raise_unescaped_double_quote_found_error(
@@ -447,32 +455,21 @@ impl POFileParser {
                 if ![St::PM, St::PP, St::PC]
                     .contains(&self.current_state)
                 {
-                    return Err(SyntaxError::Custom {
-                        maybe_filename: MaybeFilename::new(
-                            &self.file.options.path_or_content,
-                            self.content_is_path,
+                    return Err(
+                        self.invalid_previous_continuation_error(
+                            self.current_line,
                         ),
-                        line: self.current_line,
-                        index: 0,
-                        message: "invalid previous continuation line"
-                            .to_string(),
-                    });
+                    );
                 }
 
                 let quote_index = match line.find('"') {
                     Some(index) => index,
                     None => {
-                        return Err(SyntaxError::Custom {
-                            maybe_filename: MaybeFilename::new(
-                                &self.file.options.path_or_content,
-                                self.content_is_path,
+                        return Err(
+                            self.invalid_previous_continuation_error(
+                                self.current_line,
                             ),
-                            line: self.current_line,
-                            index: 0,
-                            message:
-                                "invalid previous continuation line"
-                                    .to_string(),
-                        });
+                        );
                     }
                 };
                 let continuation = &line[quote_index..];
@@ -1720,6 +1717,28 @@ mod tests {
     }
 
     #[test]
+    fn error_when_missing_msgstr_before_next_entry_with_comment() {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "# comment\n",
+            "msgid \"next\"\n",
+            "msgstr \"ok\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 3,
+                index: 0,
+                message: "missing 'msgstr' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
     fn error_when_missing_plural_msgstr_before_next_entry() {
         let content = concat!(
             "msgid \"hello\"\n",
@@ -1736,6 +1755,29 @@ mod tests {
             Err(SyntaxError::Custom {
                 maybe_filename: MaybeFilename::new(content, false,),
                 line: 3,
+                index: 0,
+                message: "missing plural 'msgstr[n]' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn error_when_missing_plural_msgstr_before_next_entry_with_comment() {
+        let content = concat!(
+            "msgid \"hello\"\n",
+            "msgid_plural \"hellos\"\n",
+            "# comment\n",
+            "msgid \"next\"\n",
+            "msgstr \"ok\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false,),
+                line: 4,
                 index: 0,
                 message: "missing plural 'msgstr[n]' section".to_string(),
             })

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -68,7 +68,7 @@ struct LinesHandler<'a> {
 }
 
 impl LinesHandler<'_> {
-    fn new(handler: &mut dyn Read) -> LinesHandler {
+    fn new(handler: &mut dyn Read) -> LinesHandler<'_> {
         LinesHandler {
             lines: BufReader::new(handler).lines(),
         }

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -1424,6 +1424,10 @@ mod tests {
         parser.parse()?;
 
         assert_eq!(parser.file.entries.len(), 2);
+        assert_eq!(
+            parser.file.entries[1].previous_msgid.as_deref(),
+            Some("Bar baz qux"),
+        );
         Ok(())
     }
 
@@ -1634,6 +1638,27 @@ mod tests {
                 line: 3,
                 index: 0,
                 message: "missing plural 'msgstr[n]' section".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn error_when_dangling_previous_continuation_line() {
+        let content = concat!(
+            "#| \"dangling\"\n",
+            "msgid \"foo\"\n",
+            "msgstr \"bar\"\n",
+        );
+        let mut parser = POFileParser::new(content.into());
+        let result = parser.parse();
+
+        assert_eq!(
+            result,
+            Err(SyntaxError::Custom {
+                maybe_filename: MaybeFilename::new(content, false),
+                line: 1,
+                index: 0,
+                message: "invalid previous continuation line".to_string(),
             })
         );
     }

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -444,6 +444,46 @@ impl POFileParser {
             // Remove the marker and any whitespace following it
             if tokens[1].starts_with('"') {
                 // Continuation of previous metadata
+                if ![St::PM, St::PP, St::PC]
+                    .contains(&self.current_state)
+                {
+                    return Err(SyntaxError::Custom {
+                        message: "invalid previous continuation line"
+                            .to_string(),
+                        maybe_filename: MaybeFilename::new(
+                            &self.file.options.path_or_content,
+                            self.content_is_path,
+                        ),
+                        line: self.current_line,
+                        index: 0,
+                    });
+                }
+
+                let quote_index = match line.find('"') {
+                    Some(index) => index,
+                    None => {
+                        return Err(SyntaxError::Custom {
+                            message:
+                                "invalid previous continuation line"
+                                    .to_string(),
+                            maybe_filename: MaybeFilename::new(
+                                &self.file.options.path_or_content,
+                                self.content_is_path,
+                            ),
+                            line: self.current_line,
+                            index: 0,
+                        });
+                    }
+                };
+                let continuation = &line[quote_index..];
+                maybe_raise_unescaped_double_quote_found_error(
+                    continuation,
+                    self.current_line,
+                    self.content_is_path,
+                    &self.file.options.path_or_content,
+                    quote_index + 1,
+                )?;
+                self.current_token = continuation.to_string();
                 self.process(&St::MC)?;
                 return Ok(());
             }
@@ -1715,7 +1755,7 @@ mod tests {
         assert_eq!(
             result,
             Err(SyntaxError::Custom {
-                maybe_filename: MaybeFilename::new(content, false),
+                maybe_filename: MaybeFilename::new(content, false,),
                 line: 1,
                 index: 0,
                 message: "invalid previous continuation line".to_string(),

--- a/rust/src/poparser.rs
+++ b/rust/src/poparser.rs
@@ -448,14 +448,14 @@ impl POFileParser {
                     .contains(&self.current_state)
                 {
                     return Err(SyntaxError::Custom {
-                        message: "invalid previous continuation line"
-                            .to_string(),
                         maybe_filename: MaybeFilename::new(
                             &self.file.options.path_or_content,
                             self.content_is_path,
                         ),
                         line: self.current_line,
                         index: 0,
+                        message: "invalid previous continuation line"
+                            .to_string(),
                     });
                 }
 
@@ -463,15 +463,15 @@ impl POFileParser {
                     Some(index) => index,
                     None => {
                         return Err(SyntaxError::Custom {
-                            message:
-                                "invalid previous continuation line"
-                                    .to_string(),
                             maybe_filename: MaybeFilename::new(
                                 &self.file.options.path_or_content,
                                 self.content_is_path,
                             ),
                             line: self.current_line,
                             index: 0,
+                            message:
+                                "invalid previous continuation line"
+                                    .to_string(),
                         });
                     }
                 };


### PR DESCRIPTION
## Resolved Issues:
- Incomplete entries (msgctxt/msgid without msgstr) could trigger a panic when a new entry begins.
- Previous-translation continuation lines (#| "...") could be accepted without a preceding #| msgid/msgctxt/msgid_plural context.

## Motivation:
I mainly use rspolib to maintain translation files and to validate incoming PRs.
 In my workflow, PO files with SyntaxError issues sometimes arrive, so I needed better resilience against malformed PO files.

## Summary:
- Return a SyntaxError instead of panicking when msgctxt/msgid exists without msgstr and a new entry begins.
- Detect missing msgstr even when a new entry starts after comments by validating entry completeness at msgctxt/msgid boundaries.
- Centralize missing msgstr/plural error creation and entry-start detection for consistent end-of-file handling.
- Reject dangling previous-translation continuations (#| "...") with a clear SyntaxError.
- Add regression tests for missing msgstr across comment boundaries, plural msgstr omissions, dangling #| continuations, and conflict-marker lines.

## Example

Example 1:
When an entry has msgctxt/msgid but no msgstr, and a new entry starts, the parser used to panic. Example:

```po
msgctxt "context:"
msgid "hello"

msgctxt "next:"
msgid "foo"
msgstr "bar"
```

Example 2:
Dangling previous-translation continuation lines (a #| "..." without a preceding #| msgid/msgctxt/msgid_plural) should fail clearly. Example:

```po
#| "dangling"
msgid "foo"
msgstr "bar"
```

## Notes:
- Panic is reproducible on commit 87cb7a3a with the example above; the parser panics on `Option::unwrap()` in `poparser.rs`.
- `#| msgstr` is rejected by polib and GNU gettext as an unknown keyword (consistent with rspolib).
- Before this change, missing-msgstr cases behaved inconsistently: with a blank line or no blank line it panicked, while a comment in between could slip through without an error.

